### PR TITLE
prepare for version 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2021-03-02
+
+### Added
+
+- `From` impls for converting a `&Utf8Path` or a `Utf8PathBuf` into `Box<Path>`, `Rc<Path>`, `Arc<Path>` and `Cow<'a, Path>`.
+- `PartialEq` and `PartialOrd` implementations comparing `Utf8Path` and `Utf8PathBuf` with `Path`, `PathBuf` and its
+  variants, and comparing `OsStr`, `OsString` and its variants.
+
 ## [1.0.1] - 2021-02-25
 
 ### Added
@@ -14,5 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release.
 
+[1.0.2]: https://github.com/withoutboats/camino/releases/tag/camino-1.0.2
 [1.0.1]: https://github.com/withoutboats/camino/releases/tag/camino-1.0.1
 [1.0.0]: https://github.com/withoutboats/camino/releases/tag/camino-1.0.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "camino"
 description = "UTF-8 paths"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,20 +515,6 @@ impl Utf8Path {
         path.as_os_str().to_str().map(|s| Utf8Path::new(s))
     }
 
-    /// Yields the underlying [`Path`] slice.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use camino::Utf8Path;
-    ///
-    /// let std_path = Utf8Path::new("foo.txt").as_std_path();
-    /// assert_eq!(std_path, std::path::Path::new("foo.txt"));
-    /// ```
-    pub fn as_std_path(&self) -> &Path {
-        &self.0
-    }
-
     /// Yields the underlying [`str`] slice.
     ///
     /// Unlike [`Path::to_str`], this always returns a slice because the contents of a `Utf8Path`
@@ -1740,7 +1726,7 @@ impl<T: ?Sized + AsRef<str>> From<&T> for Box<Utf8Path> {
 
 impl From<&'_ Utf8Path> for Arc<Utf8Path> {
     fn from(path: &Utf8Path) -> Arc<Utf8Path> {
-        let arc: Arc<Path> = Arc::from(path.as_std_path());
+        let arc: Arc<Path> = Arc::from(path.as_ref());
         let ptr = Arc::into_raw(arc) as *const Utf8Path;
         // SAFETY:
         // * path is valid UTF-8
@@ -1753,7 +1739,7 @@ impl From<&'_ Utf8Path> for Arc<Utf8Path> {
 
 impl From<&'_ Utf8Path> for Rc<Utf8Path> {
     fn from(path: &Utf8Path) -> Rc<Utf8Path> {
-        let rc: Rc<Path> = Rc::from(path.as_std_path());
+        let rc: Rc<Path> = Rc::from(path.as_ref());
         let ptr = Rc::into_raw(rc) as *const Utf8Path;
         // SAFETY:
         // * path is valid UTF-8


### PR DESCRIPTION
Decided to back out `as_std_path` because it can be replaced with
Path::as_ref, and I'm not sure about the name.